### PR TITLE
feat: Win32システムトレイ常駐 (#1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -308,6 +308,12 @@ pub fn build(b: *std.Build) void {
     });
     model_manager_mod.addImport("console", console_mod);
 
+    const config_mod = b.createModule(.{
+        .root_source_file = b.path("src/config.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     // =================================================================
     // Win32 GUI modules (Windows only, controlled by -Dgui)
     // =================================================================
@@ -325,6 +331,13 @@ pub fn build(b: *std.Build) void {
         });
         tray_mod.addImport("messages", messages_mod);
 
+        const settings_mod = b.createModule(.{
+            .root_source_file = b.path("src/win32/settings.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        settings_mod.addImport("config", config_mod);
+
         const mod = b.createModule(.{
             .root_source_file = b.path("src/win32/gui.zig"),
             .target = target,
@@ -333,6 +346,8 @@ pub fn build(b: *std.Build) void {
         mod.addImport("tray", tray_mod);
         mod.addImport("messages", messages_mod);
         mod.addImport("console", console_mod);
+        mod.addImport("config", config_mod);
+        mod.addImport("settings", settings_mod);
 
         break :blk mod;
     } else null;

--- a/build.zig
+++ b/build.zig
@@ -27,6 +27,7 @@ pub fn build(b: *std.Build) void {
     //
     const enable_cuda = b.option(bool, "cuda", "Enable CUDA GPU backend (requires CUDA Toolkit)") orelse false;
     const enable_vulkan = b.option(bool, "vulkan", "Enable Vulkan GPU backend (requires Vulkan SDK; shader compilation must be done separately)") orelse false;
+    const enable_gui = b.option(bool, "gui", "Enable Win32 GUI mode (Windows only)") orelse (target.result.os.tag == .windows);
 
     // --- Paths ---
     const ggml_src = b.path("libs/whisper.cpp/ggml/src");
@@ -308,6 +309,41 @@ pub fn build(b: *std.Build) void {
     model_manager_mod.addImport("console", console_mod);
 
     // =================================================================
+    // Win32 GUI modules (Windows only, controlled by -Dgui)
+    // =================================================================
+    const gui_mod = if (enable_gui) blk: {
+        const messages_mod = b.createModule(.{
+            .root_source_file = b.path("src/win32/messages.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+
+        const tray_mod = b.createModule(.{
+            .root_source_file = b.path("src/win32/tray.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        tray_mod.addImport("messages", messages_mod);
+
+        const mod = b.createModule(.{
+            .root_source_file = b.path("src/win32/gui.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        mod.addImport("tray", tray_mod);
+        mod.addImport("messages", messages_mod);
+        mod.addImport("console", console_mod);
+
+        break :blk mod;
+    } else null;
+
+    // =================================================================
+    // Build options (passed to main.zig at comptime)
+    // =================================================================
+    const options = b.addOptions();
+    options.addOption(bool, "enable_gui", enable_gui);
+
+    // =================================================================
     // Main executable
     // =================================================================
     const exe_mod = b.createModule(.{
@@ -325,6 +361,10 @@ pub fn build(b: *std.Build) void {
     exe_mod.addImport("clipboard_hook", clipboard_hook_mod);
     exe_mod.addImport("model_manager", model_manager_mod);
     exe_mod.addImport("console", console_mod);
+    exe_mod.addImport("build_options", options.createModule());
+    if (gui_mod) |mod| {
+        exe_mod.addImport("win32_gui", mod);
+    }
 
     const exe = b.addExecutable(.{
         .name = "rewright",
@@ -361,6 +401,11 @@ pub fn build(b: *std.Build) void {
     if (target_info.os.tag == .windows) {
         exe.linkSystemLibrary("ole32");
         exe.linkSystemLibrary("winmm");
+        if (enable_gui) {
+            exe.linkSystemLibrary("user32");
+            exe.linkSystemLibrary("shell32");
+            exe.linkSystemLibrary("gdi32");
+        }
     } else {
         exe.linkSystemLibrary("pthread");
         exe.linkSystemLibrary("m");

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,0 +1,219 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const c_env = @cImport({
+    @cInclude("stdlib.h");
+});
+
+fn getEnv(key: [*:0]const u8) ?[:0]const u8 {
+    const val = c_env.getenv(key) orelse return null;
+    return std.mem.span(val);
+}
+
+pub const default_system_prompt =
+    "You are a helpful assistant that cleans up speech-to-text transcriptions. " ++
+    "Fix grammar, punctuation, and formatting while preserving the original meaning.";
+
+pub const Config = struct {
+    allocator: std.mem.Allocator,
+
+    whisper_model: []const u8,
+    language: []const u8,
+    llm_enabled: bool,
+    llm_api_url: []const u8,
+    llm_api_key: []const u8,
+    llm_model: []const u8,
+    llm_system_prompt: []const u8,
+    clipboard_enabled: bool,
+    paste_enabled: bool,
+
+    /// Tracks whether string fields were allocated (true after load from file).
+    strings_allocated: bool,
+
+    /// Create a Config with default values. All string fields point to
+    /// comptime literals so no allocation is performed.
+    pub fn init(allocator: std.mem.Allocator) Config {
+        return .{
+            .allocator = allocator,
+            .whisper_model = "base",
+            .language = "auto",
+            .llm_enabled = false,
+            .llm_api_url = "https://api.openai.com/v1/chat/completions",
+            .llm_api_key = "",
+            .llm_model = "gpt-4o-mini",
+            .llm_system_prompt = default_system_prompt,
+            .clipboard_enabled = true,
+            .paste_enabled = false,
+            .strings_allocated = false,
+        };
+    }
+
+    /// Load configuration from the platform-specific JSON file.
+    /// Falls back to defaults when the file does not exist or cannot be parsed.
+    pub fn load(allocator: std.mem.Allocator) Config {
+        var config = init(allocator);
+
+        const path = getConfigFilePath() orelse return config;
+
+        const file = std.fs.cwd().openFile(path, .{}) catch return config;
+        defer file.close();
+
+        const max_size = 256 * 1024; // 256 KiB should be more than enough
+        const contents = file.readToEndAlloc(allocator, max_size) catch return config;
+        defer allocator.free(contents);
+
+        const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{}) catch return config;
+        defer parsed.deinit();
+
+        const root = parsed.value;
+        if (root != .object) return config;
+
+        const obj = root.object;
+
+        // Helper: extract a string value and dupe it with our allocator.
+        const S = struct {
+            fn getString(map: std.json.ObjectMap, key: []const u8, alloc: std.mem.Allocator) ?[]const u8 {
+                const val = map.get(key) orelse return null;
+                if (val != .string) return null;
+                return alloc.dupe(u8, val.string) catch return null;
+            }
+            fn getBool(map: std.json.ObjectMap, key: []const u8) ?bool {
+                const val = map.get(key) orelse return null;
+                if (val != .bool) return null;
+                return val.bool;
+            }
+        };
+
+        // Once we start reading from the file, mark strings as allocated so
+        // deinit knows to free them. We allocate dupes for every string field
+        // (even those that keep their default value) to make cleanup uniform.
+        config.strings_allocated = true;
+
+        config.whisper_model = S.getString(obj, "whisper_model", allocator) orelse
+            allocator.dupe(u8, "base") catch "base";
+        config.language = S.getString(obj, "language", allocator) orelse
+            allocator.dupe(u8, "auto") catch "auto";
+        config.llm_api_url = S.getString(obj, "llm_api_url", allocator) orelse
+            allocator.dupe(u8, "https://api.openai.com/v1/chat/completions") catch "https://api.openai.com/v1/chat/completions";
+        config.llm_api_key = S.getString(obj, "llm_api_key", allocator) orelse
+            allocator.dupe(u8, "") catch "";
+        config.llm_model = S.getString(obj, "llm_model", allocator) orelse
+            allocator.dupe(u8, "gpt-4o-mini") catch "gpt-4o-mini";
+        config.llm_system_prompt = S.getString(obj, "llm_system_prompt", allocator) orelse
+            allocator.dupe(u8, default_system_prompt) catch default_system_prompt;
+
+        if (S.getBool(obj, "llm_enabled")) |v| config.llm_enabled = v;
+        if (S.getBool(obj, "clipboard_enabled")) |v| config.clipboard_enabled = v;
+        if (S.getBool(obj, "paste_enabled")) |v| config.paste_enabled = v;
+
+        return config;
+    }
+
+    /// Serialize the configuration to a human-readable JSON file, creating
+    /// parent directories as needed.
+    pub fn save(self: *const Config) !void {
+        const path = getConfigFilePath() orelse return error.NoConfigPath;
+
+        // Ensure the parent directory exists.
+        if (std.fs.path.dirname(path)) |dir| {
+            std.fs.cwd().makePath(dir) catch {};
+        }
+
+        const file = try std.fs.cwd().createFile(path, .{});
+        defer file.close();
+
+        const writer = file.deprecatedWriter();
+
+        try writer.writeAll("{\n");
+        try writeStringField(writer, "whisper_model", self.whisper_model, true);
+        try writeStringField(writer, "language", self.language, true);
+        try writeBoolField(writer, "llm_enabled", self.llm_enabled, true);
+        try writeStringField(writer, "llm_api_url", self.llm_api_url, true);
+        try writeStringField(writer, "llm_api_key", self.llm_api_key, true);
+        try writeStringField(writer, "llm_model", self.llm_model, true);
+        try writeStringField(writer, "llm_system_prompt", self.llm_system_prompt, true);
+        try writeBoolField(writer, "clipboard_enabled", self.clipboard_enabled, true);
+        try writeBoolField(writer, "paste_enabled", self.paste_enabled, false);
+        try writer.writeAll("}\n");
+    }
+
+    /// Free all allocated string fields. Safe to call on a Config created
+    /// with `init()` (no-op since nothing was allocated).
+    pub fn deinit(self: *Config) void {
+        if (!self.strings_allocated) return;
+
+        self.allocator.free(self.whisper_model);
+        self.allocator.free(self.language);
+        self.allocator.free(self.llm_api_url);
+        self.allocator.free(self.llm_api_key);
+        self.allocator.free(self.llm_model);
+        self.allocator.free(self.llm_system_prompt);
+
+        self.strings_allocated = false;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the platform-specific config file path into a static buffer.
+fn getConfigFilePath() ?[]const u8 {
+    const S = struct {
+        var buf: [4096]u8 = undefined;
+    };
+
+    if (comptime builtin.os.tag == .windows) {
+        const appdata = getEnv("APPDATA") orelse return null;
+        const path = std.fmt.bufPrint(&S.buf, "{s}\\rewright\\config.json", .{appdata}) catch return null;
+        return path;
+    } else {
+        const xdg = getEnv("XDG_CONFIG_HOME");
+        if (xdg) |config_home| {
+            const path = std.fmt.bufPrint(&S.buf, "{s}/rewright/config.json", .{config_home}) catch return null;
+            return path;
+        }
+        const home = getEnv("HOME") orelse return null;
+        const path = std.fmt.bufPrint(&S.buf, "{s}/.config/rewright/config.json", .{home}) catch return null;
+        return path;
+    }
+}
+
+/// Write a JSON-escaped string value (without surrounding quotes) to the writer.
+fn writeJsonEscapedString(writer: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            else => {
+                if (c < 0x20) {
+                    try writer.print("\\u{x:0>4}", .{@as(u16, c)});
+                } else {
+                    try writer.writeByte(c);
+                }
+            },
+        }
+    }
+}
+
+fn writeStringField(writer: anytype, key: []const u8, value: []const u8, trailing_comma: bool) !void {
+    try writer.writeAll("    \"");
+    try writer.writeAll(key);
+    try writer.writeAll("\": \"");
+    try writeJsonEscapedString(writer, value);
+    try writer.writeByte('"');
+    if (trailing_comma) try writer.writeByte(',');
+    try writer.writeByte('\n');
+}
+
+fn writeBoolField(writer: anytype, key: []const u8, value: bool, trailing_comma: bool) !void {
+    try writer.writeAll("    \"");
+    try writer.writeAll(key);
+    try writer.writeAll("\": ");
+    try writer.writeAll(if (value) "true" else "false");
+    if (trailing_comma) try writer.writeByte(',');
+    try writer.writeByte('\n');
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,7 +53,7 @@ pub fn main() !void {
     var cli_llm_model: ?[:0]const u8 = null;
     var cli_verbose: bool = false;
     var cli_clipboard: bool = false;
-    var cli_gui: bool = false;
+    var cli_cli: bool = false;
 
     var i: usize = 1; // skip argv[0]
     while (i < args.len) : (i += 1) {
@@ -114,8 +114,8 @@ pub fn main() !void {
             cli_verbose = true;
         } else if (std.mem.eql(u8, arg, "--clipboard")) {
             cli_clipboard = true;
-        } else if (std.mem.eql(u8, arg, "--gui")) {
-            cli_gui = true;
+        } else if (std.mem.eql(u8, arg, "--cli")) {
+            cli_cli = true;
         } else {
             log("Error: Unknown argument '{s}'\n", .{arg});
             model_manager.printUsage();
@@ -124,16 +124,12 @@ pub fn main() !void {
     }
 
     // =========================================================================
-    // GUI mode: launch Win32 GUI and exit
+    // GUI mode: default when GUI is compiled in, unless --cli is specified
     // =========================================================================
-    if (cli_gui) {
-        if (comptime build_options.enable_gui) {
+    if (comptime build_options.enable_gui) {
+        if (!cli_cli) {
             win32_gui.run();
             return;
-        } else {
-            log("Error: GUI mode is not available on this platform.\n", .{});
-            log("GUI mode requires Windows and building with -Dgui=true.\n", .{});
-            std.process.exit(1);
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,8 @@ const LlmConfig = @import("llm_hook").LlmConfig;
 const ClipboardHook = @import("clipboard_hook").ClipboardHook;
 const model_manager = @import("model_manager");
 const console = @import("console");
+const build_options = @import("build_options");
+const win32_gui = if (build_options.enable_gui) @import("win32_gui") else undefined;
 
 const c_env = @cImport({
     @cInclude("stdlib.h");
@@ -51,6 +53,7 @@ pub fn main() !void {
     var cli_llm_model: ?[:0]const u8 = null;
     var cli_verbose: bool = false;
     var cli_clipboard: bool = false;
+    var cli_gui: bool = false;
 
     var i: usize = 1; // skip argv[0]
     while (i < args.len) : (i += 1) {
@@ -111,9 +114,25 @@ pub fn main() !void {
             cli_verbose = true;
         } else if (std.mem.eql(u8, arg, "--clipboard")) {
             cli_clipboard = true;
+        } else if (std.mem.eql(u8, arg, "--gui")) {
+            cli_gui = true;
         } else {
             log("Error: Unknown argument '{s}'\n", .{arg});
             model_manager.printUsage();
+            std.process.exit(1);
+        }
+    }
+
+    // =========================================================================
+    // GUI mode: launch Win32 GUI and exit
+    // =========================================================================
+    if (cli_gui) {
+        if (comptime build_options.enable_gui) {
+            win32_gui.run();
+            return;
+        } else {
+            log("Error: GUI mode is not available on this platform.\n", .{});
+            log("GUI mode requires Windows and building with -Dgui=true.\n", .{});
             std.process.exit(1);
         }
     }

--- a/src/win32/gui.zig
+++ b/src/win32/gui.zig
@@ -54,7 +54,7 @@ pub fn run() void {
     }
 
     // Initialize system tray
-    g_tray = Tray.init(@ptrCast(hwnd.?));
+    g_tray = Tray.init(@intFromPtr(hwnd.?));
     log("System tray icon created.\n", .{});
 
     // Message loop
@@ -82,12 +82,10 @@ fn wndProc(hwnd: win.HWND, uMsg: c_uint, wParam: win.WPARAM, lParam: win.LPARAM)
             switch (event) {
                 win.WM_RBUTTONUP => {
                     if (g_tray) |*tray| {
-                        tray.showContextMenu(@ptrCast(hwnd.?));
+                        tray.showContextMenu(@intFromPtr(hwnd.?));
                     }
                 },
-                win.WM_LBUTTONDBLCLK => {
-                    // Future: toggle overlay or show settings
-                },
+                win.WM_LBUTTONDBLCLK => {},
                 else => {},
             }
             return 0;

--- a/src/win32/gui.zig
+++ b/src/win32/gui.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Tray = @import("tray").Tray;
+const messages = @import("messages");
+const console = @import("console");
+
+const win = @cImport({
+    @cDefine("WIN32_LEAN_AND_MEAN", "");
+    @cInclude("windows.h");
+});
+
+var g_tray: ?Tray = null;
+
+fn log(comptime fmt: []const u8, args: anytype) void {
+    console.stderr().print(fmt, args);
+}
+
+pub fn run() void {
+    log("Starting GUI mode...\n", .{});
+
+    const hInstance: win.HINSTANCE = @ptrCast(win.GetModuleHandleW(null));
+
+    // Register window class
+    var wc: win.WNDCLASSEXW = std.mem.zeroes(win.WNDCLASSEXW);
+    wc.cbSize = @sizeOf(win.WNDCLASSEXW);
+    wc.lpfnWndProc = wndProc;
+    wc.hInstance = hInstance;
+    wc.lpszClassName = toUtf16("RewrightWindowClass");
+
+    if (win.RegisterClassExW(&wc) == 0) {
+        log("Error: Failed to register window class.\n", .{});
+        return;
+    }
+
+    // Create a hidden message-only window
+    const hwnd = win.CreateWindowExW(
+        0, // dwExStyle
+        toUtf16("RewrightWindowClass"),
+        toUtf16("rewright"),
+        0, // dwStyle (hidden)
+        0,
+        0,
+        0,
+        0,
+        null,
+        null,
+        hInstance,
+        null,
+    );
+
+    if (hwnd == null) {
+        log("Error: Failed to create window.\n", .{});
+        return;
+    }
+
+    // Initialize system tray
+    g_tray = Tray.init(@ptrCast(hwnd.?));
+    log("System tray icon created.\n", .{});
+
+    // Message loop
+    var msg: win.MSG = undefined;
+    while (win.GetMessageW(&msg, null, 0, 0) > 0) {
+        _ = win.TranslateMessage(&msg);
+        _ = win.DispatchMessageW(&msg);
+    }
+
+    // Cleanup
+    if (g_tray) |*tray| {
+        tray.deinit();
+    }
+    log("GUI mode exited.\n", .{});
+}
+
+fn wndProc(hwnd: win.HWND, uMsg: c_uint, wParam: win.WPARAM, lParam: win.LPARAM) callconv(.c) win.LRESULT {
+    switch (uMsg) {
+        win.WM_COMMAND => {
+            const id: c_uint = @truncate(wParam);
+            if (Tray.handleMenuCommand(id)) return 0;
+        },
+        messages.WM_APP_TRAY_CALLBACK => {
+            const event: c_uint = @truncate(@as(c_ulonglong, @bitCast(lParam)));
+            switch (event) {
+                win.WM_RBUTTONUP => {
+                    if (g_tray) |*tray| {
+                        tray.showContextMenu(@ptrCast(hwnd.?));
+                    }
+                },
+                win.WM_LBUTTONDBLCLK => {
+                    // Future: toggle overlay or show settings
+                },
+                else => {},
+            }
+            return 0;
+        },
+        win.WM_DESTROY => {
+            win.PostQuitMessage(0);
+            return 0;
+        },
+        else => {},
+    }
+    return win.DefWindowProcW(hwnd, uMsg, wParam, lParam);
+}
+
+/// Convert a comptime ASCII string to a null-terminated UTF-16 (WCHAR) pointer.
+fn toUtf16(comptime s: []const u8) [*:0]const win.WCHAR {
+    const data = comptime blk: {
+        var buf: [s.len:0]win.WCHAR = undefined;
+        for (s, 0..) |ch, idx| {
+            buf[idx] = ch;
+        }
+        break :blk buf;
+    };
+    return &data;
+}

--- a/src/win32/gui.zig
+++ b/src/win32/gui.zig
@@ -3,6 +3,8 @@ const builtin = @import("builtin");
 const Tray = @import("tray").Tray;
 const messages = @import("messages");
 const console = @import("console");
+const Config = @import("config").Config;
+const settings = @import("settings");
 
 const win = @cImport({
     @cDefine("WIN32_LEAN_AND_MEAN", "");
@@ -10,6 +12,7 @@ const win = @cImport({
 });
 
 var g_tray: ?Tray = null;
+var g_config: Config = undefined;
 
 fn log(comptime fmt: []const u8, args: anytype) void {
     console.stderr().print(fmt, args);
@@ -17,6 +20,9 @@ fn log(comptime fmt: []const u8, args: anytype) void {
 
 pub fn run() void {
     log("Starting GUI mode...\n", .{});
+
+    // Load configuration
+    g_config = Config.load(std.heap.page_allocator);
 
     const hInstance: win.HINSTANCE = @ptrCast(win.GetModuleHandleW(null));
 
@@ -34,10 +40,10 @@ pub fn run() void {
 
     // Create a hidden message-only window
     const hwnd = win.CreateWindowExW(
-        0, // dwExStyle
+        0,
         toUtf16("RewrightWindowClass"),
         toUtf16("rewright"),
-        0, // dwStyle (hidden)
+        0,
         0,
         0,
         0,
@@ -68,6 +74,7 @@ pub fn run() void {
     if (g_tray) |*tray| {
         tray.deinit();
     }
+    g_config.deinit();
     log("GUI mode exited.\n", .{});
 }
 
@@ -75,6 +82,10 @@ fn wndProc(hwnd: win.HWND, uMsg: c_uint, wParam: win.WPARAM, lParam: win.LPARAM)
     switch (uMsg) {
         win.WM_COMMAND => {
             const id: c_uint = @truncate(wParam);
+            if (id == @import("tray").IDM_SETTINGS) {
+                openSettings(@intFromPtr(hwnd.?));
+                return 0;
+            }
             if (Tray.handleMenuCommand(id)) return 0;
         },
         messages.WM_APP_TRAY_CALLBACK => {
@@ -85,7 +96,9 @@ fn wndProc(hwnd: win.HWND, uMsg: c_uint, wParam: win.WPARAM, lParam: win.LPARAM)
                         tray.showContextMenu(@intFromPtr(hwnd.?));
                     }
                 },
-                win.WM_LBUTTONDBLCLK => {},
+                win.WM_LBUTTONDBLCLK => {
+                    openSettings(@intFromPtr(hwnd.?));
+                },
                 else => {},
             }
             return 0;
@@ -99,7 +112,14 @@ fn wndProc(hwnd: win.HWND, uMsg: c_uint, wParam: win.WPARAM, lParam: win.LPARAM)
     return win.DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
 
-/// Convert a comptime ASCII string to a null-terminated UTF-16 (WCHAR) pointer.
+fn openSettings(hwnd_raw: usize) void {
+    if (settings.showSettingsDialog(hwnd_raw, &g_config)) {
+        g_config.save() catch |err| {
+            log("Error: Failed to save config: {}\n", .{err});
+        };
+    }
+}
+
 fn toUtf16(comptime s: []const u8) [*:0]const win.WCHAR {
     const data = comptime blk: {
         var buf: [s.len:0]win.WCHAR = undefined;

--- a/src/win32/messages.zig
+++ b/src/win32/messages.zig
@@ -1,0 +1,13 @@
+/// Custom Windows message constants for inter-thread communication.
+/// Based on WM_APP (0x8000) to avoid conflicts with system messages.
+
+const win = @cImport({
+    @cDefine("WIN32_LEAN_AND_MEAN", "");
+    @cInclude("windows.h");
+});
+
+pub const WM_APP_TRAY_CALLBACK: c_uint = win.WM_APP + 1;
+pub const WM_APP_START_RECORDING: c_uint = win.WM_APP + 2;
+pub const WM_APP_STOP_RECORDING: c_uint = win.WM_APP + 3;
+pub const WM_APP_TRANSCRIPTION_DONE: c_uint = win.WM_APP + 4;
+pub const WM_APP_UPDATE_OVERLAY: c_uint = win.WM_APP + 5;

--- a/src/win32/messages.zig
+++ b/src/win32/messages.zig
@@ -1,13 +1,10 @@
 /// Custom Windows message constants for inter-thread communication.
 /// Based on WM_APP (0x8000) to avoid conflicts with system messages.
 
-const win = @cImport({
-    @cDefine("WIN32_LEAN_AND_MEAN", "");
-    @cInclude("windows.h");
-});
+const WM_APP: c_uint = 0x8000;
 
-pub const WM_APP_TRAY_CALLBACK: c_uint = win.WM_APP + 1;
-pub const WM_APP_START_RECORDING: c_uint = win.WM_APP + 2;
-pub const WM_APP_STOP_RECORDING: c_uint = win.WM_APP + 3;
-pub const WM_APP_TRANSCRIPTION_DONE: c_uint = win.WM_APP + 4;
-pub const WM_APP_UPDATE_OVERLAY: c_uint = win.WM_APP + 5;
+pub const WM_APP_TRAY_CALLBACK: c_uint = WM_APP + 1;
+pub const WM_APP_START_RECORDING: c_uint = WM_APP + 2;
+pub const WM_APP_STOP_RECORDING: c_uint = WM_APP + 3;
+pub const WM_APP_TRANSCRIPTION_DONE: c_uint = WM_APP + 4;
+pub const WM_APP_UPDATE_OVERLAY: c_uint = WM_APP + 5;

--- a/src/win32/settings.zig
+++ b/src/win32/settings.zig
@@ -26,7 +26,14 @@ const IDC_CANCEL: c_int = 110;
 
 // Window metrics
 const DLG_WIDTH: c_int = 450;
-const DLG_HEIGHT: c_int = 500;
+// Height is calculated from layout:
+// Whisper section: MARGIN + (CONTROL_HEIGHT+2) + 2*ROW_SPACING + SECTION_SPACING = 88
+// LLM section: (CONTROL_HEIGHT+2) + 4*ROW_SPACING + PROMPT_HEIGHT + SECTION_SPACING = 256
+// Output section: (CONTROL_HEIGHT+2) + 2*ROW_SPACING + SECTION_SPACING = 96
+// Buttons + margin: BUTTON_HEIGHT + MARGIN = 44
+// Title bar: ~40
+// Total: MARGIN + 88 + 256 + 96 + 44 + 40 = 540
+const DLG_HEIGHT: c_int = 550;
 const MARGIN: c_int = 16;
 const LABEL_WIDTH: c_int = 110;
 const CONTROL_HEIGHT: c_int = 24;

--- a/src/win32/settings.zig
+++ b/src/win32/settings.zig
@@ -1,0 +1,710 @@
+const std = @import("std");
+const Config = @import("config").Config;
+
+const win = @cImport({
+    @cInclude("windows.h");
+});
+
+// =========================================================================
+// Constants
+// =========================================================================
+
+const CP_UTF8: c_uint = 65001;
+
+// Control IDs
+const IDC_WHISPER_MODEL: c_int = 100;
+const IDC_WHISPER_LANGUAGE: c_int = 101;
+const IDC_LLM_ENABLED: c_int = 102;
+const IDC_LLM_API_URL: c_int = 103;
+const IDC_LLM_API_KEY: c_int = 104;
+const IDC_LLM_MODEL: c_int = 105;
+const IDC_LLM_SYSTEM_PROMPT: c_int = 106;
+const IDC_CLIPBOARD_ENABLED: c_int = 107;
+const IDC_PASTE_ENABLED: c_int = 108;
+const IDC_OK: c_int = 109;
+const IDC_CANCEL: c_int = 110;
+
+// Window metrics
+const DLG_WIDTH: c_int = 450;
+const DLG_HEIGHT: c_int = 500;
+const MARGIN: c_int = 16;
+const LABEL_WIDTH: c_int = 110;
+const CONTROL_HEIGHT: c_int = 24;
+const ROW_SPACING: c_int = 30;
+const SECTION_SPACING: c_int = 10;
+const BUTTON_WIDTH: c_int = 80;
+const BUTTON_HEIGHT: c_int = 28;
+const PROMPT_HEIGHT: c_int = 100;
+
+// ComboBox items
+const model_items = [_][]const u8{ "tiny", "base", "small", "medium", "large", "turbo" };
+const language_items = [_][]const u8{ "auto", "ja", "en", "zh", "ko", "de", "fr", "es" };
+
+// Window styles
+const WS_OVERLAPPED = @as(c_ulong, 0x00000000);
+const WS_CAPTION = @as(c_ulong, 0x00C00000);
+const WS_SYSMENU = @as(c_ulong, 0x00080000);
+const WS_CHILD = @as(c_ulong, 0x40000000);
+const WS_VISIBLE = @as(c_ulong, 0x10000000);
+const WS_TABSTOP = @as(c_ulong, 0x00010000);
+const WS_VSCROLL = @as(c_ulong, 0x00200000);
+const WS_GROUP = @as(c_ulong, 0x00020000);
+const WS_BORDER = @as(c_ulong, 0x00800000);
+
+const CBS_DROPDOWNLIST = @as(c_ulong, 0x0003);
+const CBS_HASSTRINGS = @as(c_ulong, 0x0200);
+
+const BS_AUTOCHECKBOX = @as(c_ulong, 0x0003);
+const BS_PUSHBUTTON = @as(c_ulong, 0x0000);
+
+const ES_PASSWORD = @as(c_ulong, 0x0020);
+const ES_MULTILINE = @as(c_ulong, 0x0004);
+const ES_AUTOVSCROLL = @as(c_ulong, 0x0040);
+const ES_AUTOHSCROLL = @as(c_ulong, 0x0080);
+
+// Window messages
+const CB_ADDSTRING = 0x0143;
+const CB_SETCURSEL = 0x014E;
+const CB_GETCURSEL = 0x0147;
+const BM_SETCHECK = 0x00F1;
+const BM_GETCHECK = 0x00F0;
+const BST_CHECKED: c_ulong = 1;
+const BST_UNCHECKED: c_ulong = 0;
+
+const WM_COMMAND = 0x0111;
+const WM_CLOSE = 0x0010;
+const WM_DESTROY = 0x0002;
+const WM_SETFONT = 0x0030;
+const WM_SETTEXT = 0x000C;
+const WM_GETTEXT = 0x000D;
+const WM_GETTEXTLENGTH = 0x000E;
+const WM_CREATE = 0x0001;
+
+const BN_CLICKED = 0;
+const HIWORD_SHIFT = 16;
+
+const CW_USEDEFAULT = @as(c_int, @bitCast(@as(c_uint, 0x80000000)));
+
+const SW_SHOW = 5;
+
+const COLOR_BTNFACE = 15;
+
+// =========================================================================
+// Module-level dialog state
+// =========================================================================
+
+var g_config: ?*Config = null;
+var g_result: bool = false;
+var g_dialog_hwnd: usize = 0;
+var g_parent_hwnd: usize = 0;
+var g_font: usize = 0;
+
+// Control handles stored as usize
+var g_model_combo: usize = 0;
+var g_language_combo: usize = 0;
+var g_llm_enabled_check: usize = 0;
+var g_llm_api_url_edit: usize = 0;
+var g_llm_api_key_edit: usize = 0;
+var g_llm_model_edit: usize = 0;
+var g_llm_system_prompt_edit: usize = 0;
+var g_clipboard_check: usize = 0;
+var g_paste_check: usize = 0;
+
+// =========================================================================
+// Handle conversion utilities
+// =========================================================================
+
+/// Convert a raw handle (usize) to win.HWND without alignment checks.
+fn hwndFromInt(raw: usize) win.HWND {
+    var val = raw;
+    return @as(*const win.HWND, @ptrCast(&val)).*;
+}
+
+/// Convert win.HWND to usize for storage.
+fn intFromHwnd(hwnd: win.HWND) usize {
+    return @intFromPtr(hwnd);
+}
+
+/// Convert a raw usize to HFONT.
+fn hfontFromInt(raw: usize) win.HFONT {
+    var val = raw;
+    return @as(*const win.HFONT, @ptrCast(&val)).*;
+}
+
+/// Convert a raw usize to HMENU (used for child control IDs).
+fn hmenuFromInt(raw: usize) win.HMENU {
+    var val = raw;
+    return @as(*const win.HMENU, @ptrCast(&val)).*;
+}
+
+/// Convert a raw usize to HBRUSH.
+fn hbrushFromInt(raw: usize) win.HBRUSH {
+    var val = raw;
+    return @as(*const win.HBRUSH, @ptrCast(&val)).*;
+}
+
+// =========================================================================
+// UTF-16 / UTF-8 conversion helpers
+// =========================================================================
+
+/// Convert a comptime ASCII string to a null-terminated UTF-16 (WCHAR) pointer.
+fn toUtf16(comptime s: []const u8) [*:0]const win.WCHAR {
+    const data = comptime blk: {
+        var buf: [s.len:0]win.WCHAR = undefined;
+        for (s, 0..) |ch, idx| {
+            buf[idx] = ch;
+        }
+        break :blk buf;
+    };
+    return &data;
+}
+
+/// Convert a runtime UTF-8 slice to a null-terminated UTF-16 buffer.
+/// Returns the number of wide chars written (excluding null), or 0 on failure.
+fn utf8ToUtf16(utf8: []const u8, wbuf: []win.WCHAR) usize {
+    if (utf8.len == 0) {
+        if (wbuf.len > 0) wbuf[0] = 0;
+        return 0;
+    }
+    const result = win.MultiByteToWideChar(
+        CP_UTF8,
+        0,
+        @ptrCast(utf8.ptr),
+        @intCast(utf8.len),
+        @ptrCast(wbuf.ptr),
+        @intCast(wbuf.len - 1), // leave room for null
+    );
+    if (result <= 0) {
+        if (wbuf.len > 0) wbuf[0] = 0;
+        return 0;
+    }
+    const count: usize = @intCast(result);
+    if (count < wbuf.len) {
+        wbuf[count] = 0;
+    }
+    return count;
+}
+
+/// Convert a null-terminated UTF-16 buffer to UTF-8, returning an allocated slice.
+/// Caller must free with page_allocator.
+fn utf16ToUtf8Alloc(wstr: [*]const win.WCHAR, wlen: usize) ?[]u8 {
+    if (wlen == 0) {
+        // Return an empty allocated slice
+        const buf = std.heap.page_allocator.alloc(u8, 1) catch return null;
+        buf[0] = 0;
+        return buf[0..0];
+    }
+    // First call to get required size
+    const size = win.WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        @ptrCast(wstr),
+        @intCast(wlen),
+        null,
+        0,
+        null,
+        null,
+    );
+    if (size <= 0) return null;
+    const usize_size: usize = @intCast(size);
+    const buf = std.heap.page_allocator.alloc(u8, usize_size) catch return null;
+    const written = win.WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        @ptrCast(wstr),
+        @intCast(wlen),
+        @ptrCast(buf.ptr),
+        size,
+        null,
+        null,
+    );
+    if (written <= 0) {
+        std.heap.page_allocator.free(buf);
+        return null;
+    }
+    return buf[0..@intCast(written)];
+}
+
+// =========================================================================
+// Control creation helpers
+// =========================================================================
+
+fn createLabel(parent: win.HWND, hInstance: win.HINSTANCE, text: [*:0]const win.WCHAR, x: c_int, y: c_int, w: c_int, h: c_int) void {
+    const hwnd = win.CreateWindowExW(
+        0,
+        toUtf16("STATIC"),
+        text,
+        WS_CHILD | WS_VISIBLE,
+        x,
+        y,
+        w,
+        h,
+        parent,
+        null,
+        hInstance,
+        null,
+    );
+    if (hwnd) |h_valid| {
+        _ = win.SendMessageW(h_valid, WM_SETFONT, @intFromPtr(hfontFromInt(g_font)), 1);
+    }
+}
+
+fn createEdit(parent: win.HWND, hInstance: win.HINSTANCE, id: c_int, x: c_int, y: c_int, w: c_int, h: c_int, style_extra: c_ulong) usize {
+    const style = WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER | ES_AUTOHSCROLL | style_extra;
+    const hwnd = win.CreateWindowExW(
+        0,
+        toUtf16("EDIT"),
+        toUtf16(""),
+        style,
+        x,
+        y,
+        w,
+        h,
+        parent,
+        hmenuFromInt(@intCast(id)),
+        hInstance,
+        null,
+    );
+    if (hwnd) |h_valid| {
+        _ = win.SendMessageW(h_valid, WM_SETFONT, @intFromPtr(hfontFromInt(g_font)), 1);
+        return intFromHwnd(h_valid);
+    }
+    return 0;
+}
+
+fn createComboBox(parent: win.HWND, hInstance: win.HINSTANCE, id: c_int, x: c_int, y: c_int, w: c_int, h: c_int) usize {
+    const style = WS_CHILD | WS_VISIBLE | WS_TABSTOP | CBS_DROPDOWNLIST | CBS_HASSTRINGS;
+    const hwnd = win.CreateWindowExW(
+        0,
+        toUtf16("COMBOBOX"),
+        toUtf16(""),
+        style,
+        x,
+        y,
+        w,
+        // Drop-down height (total including list area)
+        h + 200,
+        parent,
+        hmenuFromInt(@intCast(id)),
+        hInstance,
+        null,
+    );
+    if (hwnd) |h_valid| {
+        _ = win.SendMessageW(h_valid, WM_SETFONT, @intFromPtr(hfontFromInt(g_font)), 1);
+        return intFromHwnd(h_valid);
+    }
+    return 0;
+}
+
+fn createCheckBox(parent: win.HWND, hInstance: win.HINSTANCE, id: c_int, text: [*:0]const win.WCHAR, x: c_int, y: c_int, w: c_int, h: c_int) usize {
+    const style = WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_AUTOCHECKBOX;
+    const hwnd = win.CreateWindowExW(
+        0,
+        toUtf16("BUTTON"),
+        text,
+        style,
+        x,
+        y,
+        w,
+        h,
+        parent,
+        hmenuFromInt(@intCast(id)),
+        hInstance,
+        null,
+    );
+    if (hwnd) |h_valid| {
+        _ = win.SendMessageW(h_valid, WM_SETFONT, @intFromPtr(hfontFromInt(g_font)), 1);
+        return intFromHwnd(h_valid);
+    }
+    return 0;
+}
+
+fn createButton(parent: win.HWND, hInstance: win.HINSTANCE, id: c_int, text: [*:0]const win.WCHAR, x: c_int, y: c_int, w: c_int, h: c_int) void {
+    const style = WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON;
+    const hwnd = win.CreateWindowExW(
+        0,
+        toUtf16("BUTTON"),
+        text,
+        style,
+        x,
+        y,
+        w,
+        h,
+        parent,
+        hmenuFromInt(@intCast(id)),
+        hInstance,
+        null,
+    );
+    if (hwnd) |h_valid| {
+        _ = win.SendMessageW(h_valid, WM_SETFONT, @intFromPtr(hfontFromInt(g_font)), 1);
+    }
+}
+
+// =========================================================================
+// Control value helpers
+// =========================================================================
+
+fn addComboString(combo_hwnd: usize, text: []const u8) void {
+    var wbuf: [256]win.WCHAR = undefined;
+    _ = utf8ToUtf16(text, &wbuf);
+    _ = win.SendMessageW(hwndFromInt(combo_hwnd), CB_ADDSTRING, 0, @as(win.LPARAM, @bitCast(@intFromPtr(&wbuf))));
+}
+
+fn setComboSelection(combo_hwnd: usize, index: usize) void {
+    _ = win.SendMessageW(hwndFromInt(combo_hwnd), CB_SETCURSEL, index, 0);
+}
+
+fn getComboSelection(combo_hwnd: usize) usize {
+    const result = win.SendMessageW(hwndFromInt(combo_hwnd), CB_GETCURSEL, 0, 0);
+    if (result < 0) return 0;
+    return @intCast(result);
+}
+
+fn setCheckBox(check_hwnd: usize, checked: bool) void {
+    _ = win.SendMessageW(hwndFromInt(check_hwnd), BM_SETCHECK, if (checked) BST_CHECKED else BST_UNCHECKED, 0);
+}
+
+fn getCheckBox(check_hwnd: usize) bool {
+    const result = win.SendMessageW(hwndFromInt(check_hwnd), BM_GETCHECK, 0, 0);
+    return result == BST_CHECKED;
+}
+
+fn setEditText(edit_hwnd: usize, text: []const u8) void {
+    var wbuf: [2048]win.WCHAR = undefined;
+    _ = utf8ToUtf16(text, &wbuf);
+    _ = win.SendMessageW(hwndFromInt(edit_hwnd), WM_SETTEXT, 0, @as(win.LPARAM, @bitCast(@intFromPtr(&wbuf))));
+}
+
+/// Read text from an edit control, returning an allocated UTF-8 slice.
+/// Caller must free with page_allocator.
+fn getEditText(edit_hwnd: usize) ?[]u8 {
+    const len_raw = win.SendMessageW(hwndFromInt(edit_hwnd), WM_GETTEXTLENGTH, 0, 0);
+    if (len_raw <= 0) {
+        // Return empty allocated slice
+        const buf = std.heap.page_allocator.alloc(u8, 1) catch return null;
+        buf[0] = 0;
+        return buf[0..0];
+    }
+    const wlen: usize = @intCast(len_raw);
+    // Allocate wide char buffer (+1 for null)
+    const wbuf = std.heap.page_allocator.alloc(win.WCHAR, wlen + 1) catch return null;
+    defer std.heap.page_allocator.free(wbuf);
+
+    _ = win.SendMessageW(
+        hwndFromInt(edit_hwnd),
+        WM_GETTEXT,
+        wbuf.len,
+        @as(win.LPARAM, @bitCast(@intFromPtr(wbuf.ptr))),
+    );
+
+    return utf16ToUtf8Alloc(wbuf.ptr, wlen);
+}
+
+// =========================================================================
+// Find combo index matching a string value
+// =========================================================================
+
+fn findComboIndex(comptime items: []const []const u8, value: []const u8) usize {
+    for (items, 0..) |item, idx| {
+        if (std.mem.eql(u8, item, value)) return idx;
+    }
+    return 0; // default to first item
+}
+
+// =========================================================================
+// Populate controls from config
+// =========================================================================
+
+fn populateControls() void {
+    const config = g_config orelse return;
+
+    // Whisper model
+    for (&model_items) |item| {
+        addComboString(g_model_combo, item);
+    }
+    setComboSelection(g_model_combo, findComboIndex(&model_items, config.whisper_model));
+
+    // Language
+    for (&language_items) |item| {
+        addComboString(g_language_combo, item);
+    }
+    setComboSelection(g_language_combo, findComboIndex(&language_items, config.language));
+
+    // LLM settings
+    setCheckBox(g_llm_enabled_check, config.llm_enabled);
+    setEditText(g_llm_api_url_edit, config.llm_api_url);
+    setEditText(g_llm_api_key_edit, config.llm_api_key);
+    setEditText(g_llm_model_edit, config.llm_model);
+    setEditText(g_llm_system_prompt_edit, config.llm_system_prompt);
+
+    // Output settings
+    setCheckBox(g_clipboard_check, config.clipboard_enabled);
+    setCheckBox(g_paste_check, config.paste_enabled);
+}
+
+// =========================================================================
+// Read controls back into config
+// =========================================================================
+
+fn readControlsIntoConfig() void {
+    const config = g_config orelse return;
+
+    // Whisper model
+    const model_idx = getComboSelection(g_model_combo);
+    if (model_idx < model_items.len) {
+        config.whisper_model = model_items[model_idx];
+    }
+
+    // Language
+    const lang_idx = getComboSelection(g_language_combo);
+    if (lang_idx < language_items.len) {
+        config.language = language_items[lang_idx];
+    }
+
+    // LLM settings
+    config.llm_enabled = getCheckBox(g_llm_enabled_check);
+
+    if (getEditText(g_llm_api_url_edit)) |text| {
+        config.llm_api_url = text;
+    }
+    if (getEditText(g_llm_api_key_edit)) |text| {
+        config.llm_api_key = text;
+    }
+    if (getEditText(g_llm_model_edit)) |text| {
+        config.llm_model = text;
+    }
+    if (getEditText(g_llm_system_prompt_edit)) |text| {
+        config.llm_system_prompt = text;
+    }
+
+    // Output settings
+    config.clipboard_enabled = getCheckBox(g_clipboard_check);
+    config.paste_enabled = getCheckBox(g_paste_check);
+}
+
+// =========================================================================
+// Window procedure
+// =========================================================================
+
+fn settingsWndProc(hwnd: win.HWND, uMsg: c_uint, wParam: win.WPARAM, lParam: win.LPARAM) callconv(.c) win.LRESULT {
+    switch (uMsg) {
+        WM_CREATE => {
+            return 0;
+        },
+        WM_COMMAND => {
+            const id: c_int = @intCast(wParam & 0xFFFF);
+            const notification: c_uint = @truncate(wParam >> HIWORD_SHIFT);
+
+            if (notification == BN_CLICKED) {
+                if (id == IDC_OK) {
+                    readControlsIntoConfig();
+                    g_result = true;
+                    _ = win.DestroyWindow(hwnd);
+                    return 0;
+                } else if (id == IDC_CANCEL) {
+                    g_result = false;
+                    _ = win.DestroyWindow(hwnd);
+                    return 0;
+                }
+            }
+            return 0;
+        },
+        WM_CLOSE => {
+            g_result = false;
+            _ = win.DestroyWindow(hwnd);
+            return 0;
+        },
+        WM_DESTROY => {
+            // Re-enable parent window
+            if (g_parent_hwnd != 0) {
+                _ = win.EnableWindow(hwndFromInt(g_parent_hwnd), 1);
+            }
+            // Clean up font
+            if (g_font != 0) {
+                _ = win.DeleteObject(hfontFromInt(g_font));
+                g_font = 0;
+            }
+            win.PostQuitMessage(0);
+            return 0;
+        },
+        else => {},
+    }
+    return win.DefWindowProcW(hwnd, uMsg, wParam, lParam);
+}
+
+// =========================================================================
+// Public API
+// =========================================================================
+
+/// Show a modal settings dialog.
+/// Returns true if the user clicked OK (config was modified), false if Cancel.
+pub fn showSettingsDialog(parent_hwnd: usize, config: *Config) bool {
+    g_config = config;
+    g_result = false;
+    g_parent_hwnd = parent_hwnd;
+    g_dialog_hwnd = 0;
+
+    const hInstance: win.HINSTANCE = @ptrCast(win.GetModuleHandleW(null));
+
+    // Create font
+    g_font = @intFromPtr(win.CreateFontW(
+        -14, // height (negative = character height)
+        0, // width
+        0, // escapement
+        0, // orientation
+        400, // weight (FW_NORMAL)
+        0, // italic
+        0, // underline
+        0, // strikeout
+        0, // charset (DEFAULT_CHARSET)
+        0, // out precision
+        0, // clip precision
+        0, // quality
+        0, // pitch and family
+        toUtf16("Segoe UI"),
+    ));
+
+    // Register window class
+    var wc: win.WNDCLASSEXW = std.mem.zeroes(win.WNDCLASSEXW);
+    wc.cbSize = @sizeOf(win.WNDCLASSEXW);
+    wc.lpfnWndProc = settingsWndProc;
+    wc.hInstance = hInstance;
+    wc.lpszClassName = toUtf16("RewrightSettingsClass");
+    wc.hbrBackground = hbrushFromInt(COLOR_BTNFACE + 1);
+    wc.hCursor = win.LoadCursorW(null, @ptrFromInt(32512)); // IDC_ARROW
+
+    _ = win.RegisterClassExW(&wc);
+
+    // Center on screen
+    const screen_w = win.GetSystemMetrics(0); // SM_CXSCREEN
+    const screen_h = win.GetSystemMetrics(1); // SM_CYSCREEN
+    const x = @divTrunc(screen_w - DLG_WIDTH, 2);
+    const y = @divTrunc(screen_h - DLG_HEIGHT, 2);
+
+    // Create dialog window
+    const dialog = win.CreateWindowExW(
+        0,
+        toUtf16("RewrightSettingsClass"),
+        toUtf16("rewright - Settings"),
+        WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU,
+        x,
+        y,
+        DLG_WIDTH,
+        DLG_HEIGHT,
+        if (parent_hwnd != 0) hwndFromInt(parent_hwnd) else null,
+        null,
+        hInstance,
+        null,
+    );
+
+    if (dialog == null) {
+        if (g_font != 0) {
+            _ = win.DeleteObject(hfontFromInt(g_font));
+            g_font = 0;
+        }
+        return false;
+    }
+
+    const dlg_hwnd = dialog.?;
+    g_dialog_hwnd = intFromHwnd(dlg_hwnd);
+
+    // Disable parent to make dialog modal
+    if (parent_hwnd != 0) {
+        _ = win.EnableWindow(hwndFromInt(parent_hwnd), 0);
+    }
+
+    // =====================================================================
+    // Create controls
+    // =====================================================================
+    const content_width = DLG_WIDTH - 2 * MARGIN - 16; // account for window border
+    const edit_x = MARGIN + LABEL_WIDTH + 4;
+    const edit_width = content_width - LABEL_WIDTH - 4;
+    var cur_y: c_int = MARGIN;
+
+    // --- Section: Whisper ---
+    createLabel(dlg_hwnd, hInstance, toUtf16("Whisper"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    cur_y += CONTROL_HEIGHT + 2;
+
+    // Model
+    createLabel(dlg_hwnd, hInstance, toUtf16("Model:"), MARGIN, cur_y + 2, LABEL_WIDTH, CONTROL_HEIGHT);
+    g_model_combo = createComboBox(dlg_hwnd, hInstance, IDC_WHISPER_MODEL, edit_x, cur_y, edit_width, CONTROL_HEIGHT);
+    cur_y += ROW_SPACING;
+
+    // Language
+    createLabel(dlg_hwnd, hInstance, toUtf16("Language:"), MARGIN, cur_y + 2, LABEL_WIDTH, CONTROL_HEIGHT);
+    g_language_combo = createComboBox(dlg_hwnd, hInstance, IDC_WHISPER_LANGUAGE, edit_x, cur_y, edit_width, CONTROL_HEIGHT);
+    cur_y += ROW_SPACING + SECTION_SPACING;
+
+    // --- Section: LLM ---
+    createLabel(dlg_hwnd, hInstance, toUtf16("LLM"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    cur_y += CONTROL_HEIGHT + 2;
+
+    // Enable LLM checkbox
+    g_llm_enabled_check = createCheckBox(dlg_hwnd, hInstance, IDC_LLM_ENABLED, toUtf16("Enable LLM cleanup"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    cur_y += ROW_SPACING;
+
+    // API URL
+    createLabel(dlg_hwnd, hInstance, toUtf16("API URL:"), MARGIN, cur_y + 2, LABEL_WIDTH, CONTROL_HEIGHT);
+    g_llm_api_url_edit = createEdit(dlg_hwnd, hInstance, IDC_LLM_API_URL, edit_x, cur_y, edit_width, CONTROL_HEIGHT, 0);
+    cur_y += ROW_SPACING;
+
+    // API Key
+    createLabel(dlg_hwnd, hInstance, toUtf16("API Key:"), MARGIN, cur_y + 2, LABEL_WIDTH, CONTROL_HEIGHT);
+    g_llm_api_key_edit = createEdit(dlg_hwnd, hInstance, IDC_LLM_API_KEY, edit_x, cur_y, edit_width, CONTROL_HEIGHT, ES_PASSWORD);
+    cur_y += ROW_SPACING;
+
+    // LLM Model
+    createLabel(dlg_hwnd, hInstance, toUtf16("Model:"), MARGIN, cur_y + 2, LABEL_WIDTH, CONTROL_HEIGHT);
+    g_llm_model_edit = createEdit(dlg_hwnd, hInstance, IDC_LLM_MODEL, edit_x, cur_y, edit_width, CONTROL_HEIGHT, 0);
+    cur_y += ROW_SPACING;
+
+    // System Prompt
+    createLabel(dlg_hwnd, hInstance, toUtf16("System Prompt:"), MARGIN, cur_y + 2, LABEL_WIDTH, CONTROL_HEIGHT);
+    g_llm_system_prompt_edit = createEdit(dlg_hwnd, hInstance, IDC_LLM_SYSTEM_PROMPT, edit_x, cur_y, edit_width, PROMPT_HEIGHT, ES_MULTILINE | ES_AUTOVSCROLL | WS_VSCROLL);
+    cur_y += PROMPT_HEIGHT + SECTION_SPACING;
+
+    // --- Section: Output ---
+    createLabel(dlg_hwnd, hInstance, toUtf16("Output"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    cur_y += CONTROL_HEIGHT + 2;
+
+    // Clipboard checkbox
+    g_clipboard_check = createCheckBox(dlg_hwnd, hInstance, IDC_CLIPBOARD_ENABLED, toUtf16("Copy to clipboard"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    cur_y += ROW_SPACING;
+
+    // Paste checkbox
+    g_paste_check = createCheckBox(dlg_hwnd, hInstance, IDC_PASTE_ENABLED, toUtf16("Paste at cursor position"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    cur_y += ROW_SPACING + SECTION_SPACING;
+
+    // --- Buttons ---
+    const buttons_y = DLG_HEIGHT - BUTTON_HEIGHT - MARGIN - 40; // account for title bar
+    const ok_x = DLG_WIDTH - 2 * BUTTON_WIDTH - MARGIN - 16 - 8;
+    const cancel_x = DLG_WIDTH - BUTTON_WIDTH - MARGIN - 16;
+    createButton(dlg_hwnd, hInstance, IDC_OK, toUtf16("OK"), ok_x, buttons_y, BUTTON_WIDTH, BUTTON_HEIGHT);
+    createButton(dlg_hwnd, hInstance, IDC_CANCEL, toUtf16("Cancel"), cancel_x, buttons_y, BUTTON_WIDTH, BUTTON_HEIGHT);
+
+    // =====================================================================
+    // Populate controls from config
+    // =====================================================================
+    populateControls();
+
+    // Show the dialog
+    _ = win.ShowWindow(dlg_hwnd, SW_SHOW);
+    _ = win.UpdateWindow(dlg_hwnd);
+
+    // =====================================================================
+    // Local message loop
+    // =====================================================================
+    var msg: win.MSG = undefined;
+    while (win.GetMessageW(&msg, null, 0, 0) > 0) {
+        // Allow Tab navigation via IsDialogMessage
+        if (win.IsDialogMessageW(dlg_hwnd, &msg) == 0) {
+            _ = win.TranslateMessage(&msg);
+            _ = win.DispatchMessageW(&msg);
+        }
+    }
+
+    // Unregister class (ignore failure)
+    _ = win.UnregisterClassW(toUtf16("RewrightSettingsClass"), hInstance);
+
+    return g_result;
+}

--- a/src/win32/settings.zig
+++ b/src/win32/settings.zig
@@ -26,12 +26,13 @@ const IDC_CANCEL: c_int = 110;
 
 // Window metrics
 const DLG_WIDTH: c_int = 450;
-const DLG_HEIGHT: c_int = 560;
+const DLG_HEIGHT: c_int = 500;
 const MARGIN: c_int = 16;
 const LABEL_WIDTH: c_int = 110;
 const CONTROL_HEIGHT: c_int = 24;
 const ROW_SPACING: c_int = 30;
 const SECTION_SPACING: c_int = 10;
+const CHECKBOX_WIDTH: c_int = 220;
 const BUTTON_WIDTH: c_int = 80;
 const BUTTON_HEIGHT: c_int = 28;
 const PROMPT_HEIGHT: c_int = 100;
@@ -640,7 +641,7 @@ pub fn showSettingsDialog(parent_hwnd: usize, config: *Config) bool {
     cur_y += CONTROL_HEIGHT + 2;
 
     // Enable LLM checkbox
-    g_llm_enabled_check = createCheckBox(dlg_hwnd, hInstance, IDC_LLM_ENABLED, toUtf16("Enable LLM cleanup"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    g_llm_enabled_check = createCheckBox(dlg_hwnd, hInstance, IDC_LLM_ENABLED, toUtf16("Enable LLM cleanup"), MARGIN, cur_y, CHECKBOX_WIDTH, CONTROL_HEIGHT);
     cur_y += ROW_SPACING;
 
     // API URL
@@ -668,15 +669,15 @@ pub fn showSettingsDialog(parent_hwnd: usize, config: *Config) bool {
     cur_y += CONTROL_HEIGHT + 2;
 
     // Clipboard checkbox
-    g_clipboard_check = createCheckBox(dlg_hwnd, hInstance, IDC_CLIPBOARD_ENABLED, toUtf16("Copy to clipboard"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    g_clipboard_check = createCheckBox(dlg_hwnd, hInstance, IDC_CLIPBOARD_ENABLED, toUtf16("Copy to clipboard"), MARGIN, cur_y, CHECKBOX_WIDTH, CONTROL_HEIGHT);
     cur_y += ROW_SPACING;
 
     // Paste checkbox
-    g_paste_check = createCheckBox(dlg_hwnd, hInstance, IDC_PASTE_ENABLED, toUtf16("Paste at cursor position"), MARGIN, cur_y, content_width, CONTROL_HEIGHT);
+    g_paste_check = createCheckBox(dlg_hwnd, hInstance, IDC_PASTE_ENABLED, toUtf16("Paste at cursor position"), MARGIN, cur_y, CHECKBOX_WIDTH, CONTROL_HEIGHT);
     cur_y += ROW_SPACING + SECTION_SPACING;
 
     // --- Buttons ---
-    const buttons_y = DLG_HEIGHT - BUTTON_HEIGHT - MARGIN - 40; // account for title bar
+    const buttons_y = cur_y;
     const ok_x = DLG_WIDTH - 2 * BUTTON_WIDTH - MARGIN - 16 - 8;
     const cancel_x = DLG_WIDTH - BUTTON_WIDTH - MARGIN - 16;
     createButton(dlg_hwnd, hInstance, IDC_OK, toUtf16("OK"), ok_x, buttons_y, BUTTON_WIDTH, BUTTON_HEIGHT);

--- a/src/win32/settings.zig
+++ b/src/win32/settings.zig
@@ -26,7 +26,7 @@ const IDC_CANCEL: c_int = 110;
 
 // Window metrics
 const DLG_WIDTH: c_int = 450;
-const DLG_HEIGHT: c_int = 500;
+const DLG_HEIGHT: c_int = 560;
 const MARGIN: c_int = 16;
 const LABEL_WIDTH: c_int = 110;
 const CONTROL_HEIGHT: c_int = 24;

--- a/src/win32/tray.zig
+++ b/src/win32/tray.zig
@@ -13,6 +13,7 @@ const NIM_ADD = 0x00000000;
 const NIM_DELETE = 0x00000002;
 
 // Context menu item IDs
+pub const IDM_SETTINGS: c_uint = 1000;
 const IDM_QUIT: c_uint = 1001;
 
 /// Convert a raw handle (usize) to win.HWND without alignment checks.
@@ -55,6 +56,8 @@ pub const Tray = struct {
         if (menu == null) return;
         defer _ = win.DestroyMenu(menu);
 
+        _ = win.AppendMenuW(menu, 0, IDM_SETTINGS, toUtf16("Settings..."));
+        _ = win.AppendMenuW(menu, 0x0800, 0, null); // MF_SEPARATOR
         _ = win.AppendMenuW(menu, 0, IDM_QUIT, toUtf16("Quit"));
 
         var pt: win.POINT = undefined;

--- a/src/win32/tray.zig
+++ b/src/win32/tray.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const messages = @import("messages");
+
+const win = @cImport({
+    @cDefine("WIN32_LEAN_AND_MEAN", "");
+    @cInclude("windows.h");
+    @cInclude("shellapi.h");
+});
+
+const NOTIFYICONDATAW = extern struct {
+    cbSize: win.DWORD,
+    hWnd: win.HWND,
+    uID: win.UINT,
+    uFlags: win.UINT,
+    uCallbackMessage: win.UINT,
+    hIcon: win.HICON,
+    szTip: [128]win.WCHAR,
+    dwState: win.DWORD = 0,
+    dwStateMask: win.DWORD = 0,
+    szInfo: [256]win.WCHAR = std.mem.zeroes([256]win.WCHAR),
+    uVersion: win.UINT = 0,
+    szInfoTitle: [64]win.WCHAR = std.mem.zeroes([64]win.WCHAR),
+    dwInfoFlags: win.DWORD = 0,
+    guidItem: win.GUID = std.mem.zeroes(win.GUID),
+    hBalloonIcon: win.HICON = null,
+};
+
+const NIF_MESSAGE = 0x00000001;
+const NIF_ICON = 0x00000002;
+const NIF_TIP = 0x00000004;
+const NIM_ADD = 0x00000000;
+const NIM_DELETE = 0x00000002;
+
+// Context menu item IDs
+const IDM_QUIT: c_uint = 1001;
+
+extern "shell32" fn Shell_NotifyIconW(dwMessage: win.DWORD, lpData: *NOTIFYICONDATAW) callconv(.c) win.BOOL;
+
+pub const Tray = struct {
+    nid: NOTIFYICONDATAW,
+
+    pub fn init(hwnd_opaque: *anyopaque) Tray {
+        const hwnd: win.HWND = @ptrCast(@alignCast(hwnd_opaque));
+        var nid: NOTIFYICONDATAW = std.mem.zeroes(NOTIFYICONDATAW);
+        nid.cbSize = @sizeOf(NOTIFYICONDATAW);
+        nid.hWnd = hwnd;
+        nid.uID = 1;
+        nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+        nid.uCallbackMessage = messages.WM_APP_TRAY_CALLBACK;
+        // Use system default application icon
+        nid.hIcon = win.LoadIconW(null, @ptrFromInt(@as(usize, 32512))); // IDI_APPLICATION = 32512
+        copyTip(&nid.szTip, "rewright");
+
+        _ = Shell_NotifyIconW(NIM_ADD, &nid);
+
+        return .{ .nid = nid };
+    }
+
+    pub fn deinit(self: *Tray) void {
+        _ = Shell_NotifyIconW(NIM_DELETE, &self.nid);
+    }
+
+    pub fn showContextMenu(self: *const Tray, hwnd_opaque: *anyopaque) void {
+        _ = self;
+        const hwnd: win.HWND = @ptrCast(@alignCast(hwnd_opaque));
+        const menu = win.CreatePopupMenu();
+        if (menu == null) return;
+        defer _ = win.DestroyMenu(menu);
+
+        _ = win.AppendMenuW(menu, 0, IDM_QUIT, toUtf16("Quit"));
+
+        // Get cursor position for menu placement
+        var pt: win.POINT = undefined;
+        _ = win.GetCursorPos(&pt);
+
+        // Required to make the menu dismiss when clicking outside
+        _ = win.SetForegroundWindow(hwnd);
+        _ = win.TrackPopupMenu(
+            menu,
+            win.TPM_BOTTOMALIGN | win.TPM_LEFTALIGN,
+            pt.x,
+            pt.y,
+            0,
+            hwnd,
+            null,
+        );
+        // Post a dummy message to force the menu to close properly
+        _ = win.PostMessageW(hwnd, win.WM_NULL, 0, 0);
+    }
+
+    pub fn handleMenuCommand(id: c_uint) bool {
+        switch (id) {
+            IDM_QUIT => {
+                win.PostQuitMessage(0);
+                return true;
+            },
+            else => return false,
+        }
+    }
+
+    fn copyTip(dest: *[128]win.WCHAR, text: []const u8) void {
+        const max_len = dest.len - 1;
+        var i: usize = 0;
+        while (i < text.len and i < max_len) : (i += 1) {
+            dest[i] = @intCast(text[i]);
+        }
+        dest[i] = 0;
+    }
+
+    fn toUtf16(comptime s: []const u8) [*:0]const win.WCHAR {
+        const data = comptime blk: {
+            var buf: [s.len:0]win.WCHAR = undefined;
+            for (s, 0..) |ch, idx| {
+                buf[idx] = ch;
+            }
+            break :blk buf;
+        };
+        return &data;
+    }
+};

--- a/src/win32/tray.zig
+++ b/src/win32/tray.zig
@@ -1,30 +1,10 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const messages = @import("messages");
 
 const win = @cImport({
-    @cDefine("WIN32_LEAN_AND_MEAN", "");
     @cInclude("windows.h");
     @cInclude("shellapi.h");
 });
-
-const NOTIFYICONDATAW = extern struct {
-    cbSize: win.DWORD,
-    hWnd: win.HWND,
-    uID: win.UINT,
-    uFlags: win.UINT,
-    uCallbackMessage: win.UINT,
-    hIcon: win.HICON,
-    szTip: [128]win.WCHAR,
-    dwState: win.DWORD = 0,
-    dwStateMask: win.DWORD = 0,
-    szInfo: [256]win.WCHAR = std.mem.zeroes([256]win.WCHAR),
-    uVersion: win.UINT = 0,
-    szInfoTitle: [64]win.WCHAR = std.mem.zeroes([64]win.WCHAR),
-    dwInfoFlags: win.DWORD = 0,
-    guidItem: win.GUID = std.mem.zeroes(win.GUID),
-    hBalloonIcon: win.HICON = null,
-};
 
 const NIF_MESSAGE = 0x00000001;
 const NIF_ICON = 0x00000002;
@@ -35,46 +15,51 @@ const NIM_DELETE = 0x00000002;
 // Context menu item IDs
 const IDM_QUIT: c_uint = 1001;
 
-extern "shell32" fn Shell_NotifyIconW(dwMessage: win.DWORD, lpData: *NOTIFYICONDATAW) callconv(.c) win.BOOL;
+/// Convert a raw handle (usize) to win.HWND without alignment checks.
+/// HWND is an opaque kernel handle, not a real pointer to struct_HWND__,
+/// so its value may not satisfy the alignment that Zig's @ptrFromInt
+/// enforces. We reinterpret the bits via a same-sized stack slot instead.
+fn hwndFromInt(raw: usize) win.HWND {
+    var val = raw;
+    return @as(*const win.HWND, @ptrCast(&val)).*;
+}
 
 pub const Tray = struct {
-    nid: NOTIFYICONDATAW,
+    nid: win.NOTIFYICONDATAW,
 
-    pub fn init(hwnd_opaque: *anyopaque) Tray {
-        const hwnd: win.HWND = @ptrCast(@alignCast(hwnd_opaque));
-        var nid: NOTIFYICONDATAW = std.mem.zeroes(NOTIFYICONDATAW);
-        nid.cbSize = @sizeOf(NOTIFYICONDATAW);
+    pub fn init(hwnd_raw: usize) Tray {
+        const hwnd: win.HWND = hwndFromInt(hwnd_raw);
+        var nid: win.NOTIFYICONDATAW = std.mem.zeroes(win.NOTIFYICONDATAW);
+        nid.cbSize = @sizeOf(win.NOTIFYICONDATAW);
         nid.hWnd = hwnd;
         nid.uID = 1;
         nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
         nid.uCallbackMessage = messages.WM_APP_TRAY_CALLBACK;
-        // Use system default application icon
-        nid.hIcon = win.LoadIconW(null, @ptrFromInt(@as(usize, 32512))); // IDI_APPLICATION = 32512
+        nid.hIcon = win.LoadIconW(null, @ptrFromInt(@as(usize, 32512))); // IDI_APPLICATION
         copyTip(&nid.szTip, "rewright");
 
-        _ = Shell_NotifyIconW(NIM_ADD, &nid);
+        _ = win.Shell_NotifyIconW(NIM_ADD, &nid);
 
         return .{ .nid = nid };
     }
 
     pub fn deinit(self: *Tray) void {
-        _ = Shell_NotifyIconW(NIM_DELETE, &self.nid);
+        _ = win.Shell_NotifyIconW(NIM_DELETE, &self.nid);
     }
 
-    pub fn showContextMenu(self: *const Tray, hwnd_opaque: *anyopaque) void {
+    pub fn showContextMenu(self: *const Tray, hwnd_raw: usize) void {
         _ = self;
-        const hwnd: win.HWND = @ptrCast(@alignCast(hwnd_opaque));
+        const hwnd: win.HWND = hwndFromInt(hwnd_raw);
+
         const menu = win.CreatePopupMenu();
         if (menu == null) return;
         defer _ = win.DestroyMenu(menu);
 
         _ = win.AppendMenuW(menu, 0, IDM_QUIT, toUtf16("Quit"));
 
-        // Get cursor position for menu placement
         var pt: win.POINT = undefined;
         _ = win.GetCursorPos(&pt);
 
-        // Required to make the menu dismiss when clicking outside
         _ = win.SetForegroundWindow(hwnd);
         _ = win.TrackPopupMenu(
             menu,
@@ -85,7 +70,6 @@ pub const Tray = struct {
             hwnd,
             null,
         );
-        // Post a dummy message to force the menu to close properly
         _ = win.PostMessageW(hwnd, win.WM_NULL, 0, 0);
     }
 


### PR DESCRIPTION
## Summary
- Win32 GUI モードを `--gui` フラグで起動可能に
- `Shell_NotifyIconW` でシステムトレイアイコンを表示、右クリックメニュー (Quit) 対応
- `src/win32/` モジュール構成 (`gui.zig`, `tray.zig`, `messages.zig`) を新設
- `-Dgui` ビルドオプションで条件コンパイル (Windowsデフォルト有効、Linux無効)
- `build_options` モジュールでコンパイル時フラグをmain.zigに伝達

## Test plan
- [x] Linux (`-Dgui=false`) ビルド成功
- [x] Windows クロスコンパイル (`-Dgui=true`) ビルド成功
- [x] `zig build test` 既存テスト回帰なし
- [ ] Windows実機で `rewright.exe --gui` 実行、トレイアイコン表示確認
- [ ] トレイ右クリック → Quit でアプリ終了確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)